### PR TITLE
Add warning that Rel JSON Pointer is not used

### DIFF
--- a/specification.md
+++ b/specification.md
@@ -13,7 +13,9 @@ Specification documents
 
 See also the release notes / change log (Work in progress).
 
-The specification is split into two parts, Core and Validation, along with a related specification, Relative JSON Pointers:
+The specification is split into two parts, Core and Validation. We also publish
+the Relative JSON Pointers spec although it's not currently used by Core or
+Validation in any significant way.
 
 |--------------------------------------------------------------|-------------------------------------------------------|
 | [JSON Schema Core](draft/2020-12/json-schema-core.html)             | defines the basic foundation of JSON Schema           |


### PR DESCRIPTION
Here's my suggestion regarding https://github.com/json-schema-org/json-schema-org.github.io/issues/374. It's a little vague, but I didn't want to overshadow the important bits with a lengthy explanation.