### PR TITLE
Fix learn schemas

### DIFF
--- a/learn/examples/address.schema.json
+++ b/learn/examples/address.schema.json
@@ -1,6 +1,6 @@
 {
   "$id": "https://example.com/address.schema.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "description": "An address similar to http://microformats.org/wiki/h-card",
   "type": "object",
   "properties": {
@@ -27,7 +27,7 @@
     }
   },
   "required": [ "locality", "region", "country-name" ],
-  "dependencies": {
+  "dependentRequired": {
     "post-office-box": [ "street-address" ],
     "extended-address": [ "street-address" ]
   }

--- a/learn/examples/calendar.schema.json
+++ b/learn/examples/calendar.schema.json
@@ -1,6 +1,6 @@
 {
   "$id": "https://example.com/calendar.schema.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "description": "A representation of an event",
   "type": "object",
   "required": [ "dtstart", "summary" ],
@@ -41,7 +41,7 @@
       "type": "string"
     },
     "geo": {
-      "$ref": "http://example.com/geographical-location.schema.json"
+      "$ref": "https://example.com/geographical-location.schema.json"
     }
   }
 }

--- a/learn/examples/card.schema.json
+++ b/learn/examples/card.schema.json
@@ -1,6 +1,6 @@
 {
   "$id": "https://example.com/card.schema.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "description": "A representation of a person, company, organization, or place",
   "type": "object",
   "required": [ "familyName", "givenName" ],
@@ -61,8 +61,8 @@
         }
       }
     },
-    "adr": { "$ref": "http://example.com/address.schema.json" },
-    "geo": { "$ref": "http://example.com/geographical-location.schema.json" },
+    "adr": { "$ref": "https://example.com/address.schema.json" },
+    "geo": { "$ref": "https://example.com/geographical-location.schema.json" },
     "tz": {
       "type": "string"
     },

--- a/learn/examples/geographical-location.schema.json
+++ b/learn/examples/geographical-location.schema.json
@@ -1,6 +1,6 @@
 {
   "$id": "https://example.com/geographical-location.schema.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Longitude and Latitude Values",
   "description": "A geographical coordinate.",
   "required": [ "latitude", "longitude" ],

--- a/learn/file-system.md
+++ b/learn/file-system.md
@@ -82,8 +82,8 @@ Building out our JSON Schema from top to bottom:
 
 ```json
 {
-  "$id": "http://example.com/fstab",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://example.com/fstab",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "type": "object",
   "required": [ "/" ],
   "properties": {
@@ -108,13 +108,13 @@ To this we add:
 * The [`oneOf`](http://json-schema.org/latest/json-schema-validation.html#rfc.section.6.7.3) keyword.
 * The [`$ref`](http://json-schema.org/latest/json-schema-core.html#rfc.section.8.3) keyword.
   * In this case, all references used are local to the schema using a relative fragment URI (`#/...`).
-* The [`definitions`](http://json-schema.org/latest/json-schema-validation.html#rfc.section.9) keyword.
+* The [`$defs`](http://json-schema.org/latest/json-schema-validation.html#rfc.section.9) keyword.
   * Including several key names which we will define later.
 
 ```json
 {
-  "$id": "http://example.com/entry-schema",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://example.com/entry-schema",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "description": "JSON Schema for an fstab entry",
   "type": "object",
   "required": [ "storage" ],
@@ -122,14 +122,14 @@ To this we add:
     "storage": {
       "type": "object",
       "oneOf": [
-        { "$ref": "#/definitions/diskDevice" },
-        { "$ref": "#/definitions/diskUUID" },
-        { "$ref": "#/definitions/nfs" },
-        { "$ref": "#/definitions/tmpfs" }
+        { "$ref": "#/$defs/diskDevice" },
+        { "$ref": "#/$defs/diskUUID" },
+        { "$ref": "#/$defs/nfs" },
+        { "$ref": "#/$defs/tmpfs" }
       ]
     }
   },
-  "definitions": {
+  "$defs": {
     "diskDevice": {},
     "diskUUID": {},
     "nfs": {},
@@ -155,8 +155,8 @@ With these added constraints, the schema now looks like this:
 
 ```json
 {
-  "$id": "http://example.com/entry-schema",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://example.com/entry-schema",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "description": "JSON Schema for an fstab entry",
   "type": "object",
   "required": [ "storage" ],
@@ -164,10 +164,10 @@ With these added constraints, the schema now looks like this:
     "storage": {
       "type": "object",
       "oneOf": [
-        { "$ref": "#/definitions/diskDevice" },
-        { "$ref": "#/definitions/diskUUID" },
-        { "$ref": "#/definitions/nfs" },
-        { "$ref": "#/definitions/tmpfs" }
+        { "$ref": "#/$defs/diskDevice" },
+        { "$ref": "#/$defs/diskUUID" },
+        { "$ref": "#/$defs/nfs" },
+        { "$ref": "#/$defs/tmpfs" }
       ]
     },
     "fstype": {
@@ -185,7 +185,7 @@ With these added constraints, the schema now looks like this:
       "type": "boolean"
     }
   },
-  "definitions": {
+  "$defs": {
     "diskDevice": {},
     "diskUUID": {},
     "nfs": {},
@@ -303,8 +303,8 @@ The resulting schema is quite large:
 
 ```json
 {
-  "$id": "http://example.com/entry-schema",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://example.com/entry-schema",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "description": "JSON Schema for an fstab entry",
   "type": "object",
   "required": [ "storage" ],
@@ -312,10 +312,10 @@ The resulting schema is quite large:
     "storage": {
       "type": "object",
       "oneOf": [
-        { "$ref": "#/definitions/diskDevice" },
-        { "$ref": "#/definitions/diskUUID" },
-        { "$ref": "#/definitions/nfs" },
-        { "$ref": "#/definitions/tmpfs" }
+        { "$ref": "#/$defs/diskDevice" },
+        { "$ref": "#/$defs/diskUUID" },
+        { "$ref": "#/$defs/nfs" },
+        { "$ref": "#/$defs/tmpfs" }
       ]
     },
     "fstype": {
@@ -333,7 +333,7 @@ The resulting schema is quite large:
       "type": "boolean"
     }
   },
-  "definitions": {
+  "$defs": {
     "diskDevice": {
       "properties": {
         "type": {
@@ -404,16 +404,16 @@ Coming full circle we use the `$ref` keyword to add our entry schema into the ke
 
 ```json
 {
-  "$id": "http://example.com/fstab",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://example.com/fstab",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "type": "object",
   "required": [ "/" ],
   "properties": {
-    "/": { "$ref": "http://example.com/entry-schema" }
+    "/": { "$ref": "https://example.com/entry-schema" }
   },
   "patternProperties": {
-    "^(/[^/]+)+$":  { "$ref": "http://example.com/entry-schema" }
+    "^(/[^/]+)+$":  { "$ref": "https://example.com/entry-schema" }
   },
-  "additionalProperties": false,
+  "additionalProperties": false
 }
 ```

--- a/learn/file-system.md
+++ b/learn/file-system.md
@@ -66,16 +66,16 @@ We will start with a base JSON Schema expressing the following constraints:
 
 Building out our JSON Schema from top to bottom:
 
-* The [`$id`](http://json-schema.org/latest/json-schema-core.html#rfc.section.8.2) keyword.
-* The [`$schema`](http://json-schema.org/latest/json-schema-core.html#rfc.section.7) keyword.
-* The [`type`](http://json-schema.org/latest/json-schema-validation.html#rfc.section.6.1.1) validation keyword.
-* The [`required`](http://json-schema.org/latest/json-schema-validation.html#rfc.section.6.5.3) validation keyword.
-* The [`properties`](http://json-schema.org/latest/json-schema-validation.html#rfc.section.6.5.4) validation keyword.
+* The [`$id`](http://json-schema.org/latest/json-schema-core.html#section.8.2.1) keyword.
+* The [`$schema`](http://json-schema.org/latest/json-schema-core.html#section.8.1.1) keyword.
+* The [`type`](http://json-schema.org/latest/json-schema-validation.html#section-6.1.1) validation keyword.
+* The [`required`](http://json-schema.org/latest/json-schema-validation.html#section-6.5.3) validation keyword.
+* The [`properties`](http://json-schema.org/latest/json-schema-core.html#section-10.3.2.1) validation keyword.
   * The `/` key is empty now; We will fill it out later.
-* The [`patternProperties`](http://json-schema.org/latest/json-schema-validation.html#rfc.section.6.5.5) validation keyword.
+* The [`patternProperties`](http://json-schema.org/latest/json-schema-core.html#section-10.3.2.2) validation keyword.
   * This matches other property names via a regular expression. Note: it does not match `/`.
   * The `^(/[^/]+)+$` key is empty now; We will fill it out later.
-* The [`additionalProperties`](http://json-schema.org/latest/json-schema-validation.html#rfc.section.6.5.6) validation keyword.
+* The [`additionalProperties`](http://json-schema.org/latest/json-schema-core.html#section-10.3.2.3) validation keyword.
   * The value here is `false` to constrain object properties to be either `/` or to match the regular expression.
 
 > You will notice that the regular expression is explicitly anchored (with `^` and `$`): in JSON Schema, regular expressions (in `patternProperties` and in `pattern`) are not anchored by default.
@@ -104,11 +104,11 @@ We saw these keywords in the prior exercise: `$id`, `$schema`, `type`, `required
 
 To this we add:
 
-* The [`description`](http://json-schema.org/latest/json-schema-validation.html#rfc.section.10.1) annotation keyword.
-* The [`oneOf`](http://json-schema.org/latest/json-schema-validation.html#rfc.section.6.7.3) keyword.
-* The [`$ref`](http://json-schema.org/latest/json-schema-core.html#rfc.section.8.3) keyword.
+* The [`description`](http://json-schema.org/latest/json-schema-validation.html#section-9.1) annotation keyword.
+* The [`oneOf`](http://json-schema.org/latest/json-schema-core.html#section-10.2.1.3) keyword.
+* The [`$ref`](http://json-schema.org/latest/json-schema-core.html#section.8.2.3.1) keyword.
   * In this case, all references used are local to the schema using a relative fragment URI (`#/...`).
-* The [`$defs`](http://json-schema.org/latest/json-schema-validation.html#rfc.section.9) keyword.
+* The [`$defs`](http://json-schema.org/latest/json-schema-core.html#section.8.2.4) keyword.
   * Including several key names which we will define later.
 
 ```json
@@ -142,12 +142,12 @@ To this we add:
 
 Let's now extend this skeleton to add constraints to some of the properties.
 
-* Our `fstype` key uses the [`enum`](http://json-schema.org/latest/json-schema-validation.html#rfc.section.6.1.2) validation keyword.
+* Our `fstype` key uses the [`enum`](http://json-schema.org/latest/json-schema-validation.html#section-6.1.2) validation keyword.
 * Our `options` key uses the following:
   * The `type` validation keyword (see above).
-  * The [`minItems`](http://json-schema.org/latest/json-schema-validation.html#rfc.section.6.4.4) validation keyword.
-  * The [`items`](http://json-schema.org/latest/json-schema-validation.html#rfc.section.6.4.1) validation keyword.
-  * The [`uniqueItems`](http://json-schema.org/latest/json-schema-validation.html#rfc.section.6.4.5) validation keyword.
+  * The [`minItems`](http://json-schema.org/latest/json-schema-validation.html#section-6.4.2) validation keyword.
+  * The [`items`](http://json-schema.org/latest/json-schema-core.html#section-10.3.1.2) validation keyword.
+  * The [`uniqueItems`](http://json-schema.org/latest/json-schema-validation.html#rfc.section.6.4.3) validation keyword.
   * Together these say: `options` must be an array, and the items therein must be strings, there must be at least one item, and all items should be unique.
 * We have a `readonly` key.
 
@@ -198,7 +198,7 @@ With these added constraints, the schema now looks like this:
 
 One new keyword is introduced here:
 
-* The [`pattern`](http://json-schema.org/latest/json-schema-validation.html#rfc.section.6.3.3) validation keyword notes the `device` key must be an absolute path starting with */dev*.
+* The [`pattern`](http://json-schema.org/latest/json-schema-validation.html#section-6.3.3) validation keyword notes the `device` key must be an absolute path starting with */dev*.
 
 ```json
 {
@@ -246,7 +246,7 @@ We do have a new key: `label` and the `pattern` validation keyword states it mus
 
 We find another new keyword:
 
-* The [`format`](http://json-schema.org/latest/json-schema-validation.html#rfc.section.7) annotation and assertion keyword.
+* The [`format`](http://json-schema.org/latest/json-schema-validation.html#section-7) annotation and assertion keyword.
 
 ```json
 {
@@ -276,8 +276,8 @@ We find another new keyword:
 
 Our last definition introduces two new keywords:
 
-* The [`minimum`](http://json-schema.org/latest/json-schema-validation.html#rfc.section.6.2.4) validation keyword.
-* The [`maximum`](http://json-schema.org/latest/json-schema-validation.html#rfc.section.6.2.2) validation keword.
+* The [`minimum`](http://json-schema.org/latest/json-schema-validation.html#section-6.2.4) validation keyword.
+* The [`maximum`](http://json-schema.org/latest/json-schema-validation.html#section-6.2.2) validation keword.
 * Together these require the size be between 16 and 512, inclusive.
 
 ```json

--- a/learn/getting-started-step-by-step.md
+++ b/learn/getting-started-step-by-step.md
@@ -50,10 +50,10 @@ We start with four properties called **keywords** which are expressed as [JSON](
 
 > Yes. the standard uses a JSON data document to describe data documents, most often that are also JSON data documents but could be in any number of other content types like `text/xml`.
 
-* The [`$schema`](http://json-schema.org/latest/json-schema-core.html#rfc.section.7) keyword states that this schema is written according to a specific draft of the standard and used for a variety of reasons, primarily version control.
-* The [`$id`](http://json-schema.org/latest/json-schema-core.html#rfc.section.8.2) keyword defines a URI for the schema, and the base URI that other URI references within the schema are resolved against.
-* The [`title`](http://json-schema.org/latest/json-schema-validation.html#rfc.section.10.1) and [`description`](http://json-schema.org/latest/json-schema-validation.html#rfc.section.10.1) annotation keywords are descriptive only. They do not add constraints to the data being validated. The intent of the schema is stated with these two keywords.
-* The [`type`](http://json-schema.org/latest/json-schema-validation.html#rfc.section.6.1.1) validation keyword defines the first constraint on our JSON data and in this case it has to be a JSON Object.
+* The [`$schema`](http://json-schema.org/latest/json-schema-core.html#section-8.1.1) keyword states that this schema is written according to a specific draft of the standard and used for a variety of reasons, primarily version control.
+* The [`$id`](http://json-schema.org/latest/json-schema-core.html#section-8.2.1) keyword defines a URI for the schema, and the base URI that other URI references within the schema are resolved against.
+* The [`title`](http://json-schema.org/latest/json-schema-validation.html#section-9.1) and [`description`](http://json-schema.org/latest/json-schema-validation.html#section-9.1) annotation keywords are descriptive only. They do not add constraints to the data being validated. The intent of the schema is stated with these two keywords.
+* The [`type`](http://json-schema.org/latest/json-schema-validation.html#section.6.1.1) validation keyword defines the first constraint on our JSON data and in this case it has to be a JSON Object.
 
 ```json
 {
@@ -67,9 +67,9 @@ We start with four properties called **keywords** which are expressed as [JSON](
 
 We introduce the following pieces of terminology when we start the schema:
 
-* [Schema Keyword](http://json-schema.org/latest/json-schema-core.html#rfc.section.4.3.1): `$schema` and `$id`.
-* [Schema Annotations](http://json-schema.org/latest/json-schema-validation.html#rfc.section.10): `title` and `description`.
-* [Validation Keyword](http://json-schema.org/latest/json-schema-validation.html#rfc.section.6): `type`.
+* [Schema Keyword](http://json-schema.org/latest/json-schema-core.html#section.8.1.1): `$schema` and `$id`.
+* [Schema Annotations](http://json-schema.org/latest/json-schema-validation.html#section-9.1): `title` and `description`.
+* [Validation Keyword](http://json-schema.org/latest/json-schema-validation.html#section-6.1.1): `type`.
 
 ## <a name="properties"></a>Defining the properties
 
@@ -77,10 +77,10 @@ We introduce the following pieces of terminology when we start the schema:
 
 In JSON Schema terms, we update our schema to add:
 
-* The [`properties`](http://json-schema.org/latest/json-schema-validation.html#rfc.section.6.5.4) validation keyword.
+* The [`properties`](http://json-schema.org/latest/json-schema-core.html#section-10.3.2.1) validation keyword.
 * The `productId` key.
   * `description` schema annotation and `type` validation keyword is noted -- we covered both of these in the previous section.
-* The [`required`](http://json-schema.org/latest/json-schema-validation.html#rfc.section.6.5.3) validation keyword listing `productId`.
+* The [`required`](http://json-schema.org/latest/json-schema-validation.html#section.6.5.3) validation keyword listing `productId`.
 
 
 ```json
@@ -130,8 +130,8 @@ In JSON Schema terms, we update our schema to add:
 According to the store owner there are no free products. ;)
 
 * The `price` key is added with the usual `description` schema annotation and `type` validation keywords covered previously. It is also included in the array of keys defined by the `required` validation keyword.
-* We specify the value of `price` must be something other than zero using the [`exclusiveMinimum`](http://json-schema.org/latest/json-schema-validation.html#rfc.section.6.2.5) validation keyword.
-  * If we wanted to include zero as a valid price we would have specified the [`minimum`](http://json-schema.org/latest/json-schema-validation.html#rfc.section.6.2.4) validation keyword.
+* We specify the value of `price` must be something other than zero using the [`exclusiveMinimum`](http://json-schema.org/latest/json-schema-validation.html#section-6.2.5) validation keyword.
+  * If we wanted to include zero as a valid price we would have specified the [`minimum`](http://json-schema.org/latest/json-schema-validation.html#section-6.2.4) validation keyword.
 
 ```json
 {
@@ -172,9 +172,9 @@ Therefore:
 
 * The `tags` key is added with the usual annotations and keywords.
 * This time the `type` validation keyword is `array`.
-* We introduce the [`items`](http://json-schema.org/latest/json-schema-validation.html#rfc.section.6.4.1) validation keyword so we can define what appears in the array. In this case: `string` values via the `type` validation keyword.
-* The [`minItems`](http://json-schema.org/latest/json-schema-validation.html#rfc.section.6.4.4) validation keyword is used to make sure there is at least one item in the array.
-* The [`uniqueItems`](http://json-schema.org/latest/json-schema-validation.html#rfc.section.6.4.5) validation keyword notes all of the items in the array must be unique relative to one another.
+* We introduce the [`items`](http://json-schema.org/latest/json-schema-core.html#section-10.3.1.2) validation keyword so we can define what appears in the array. In this case: `string` values via the `type` validation keyword.
+* The [`minItems`](http://json-schema.org/latest/json-schema-validation.html#section-6.4.2) validation keyword is used to make sure there is at least one item in the array.
+* The [`uniqueItems`](http://json-schema.org/latest/json-schema-validation.html#section-6.4.3) validation keyword notes all of the items in the array must be unique relative to one another.
 * We did not add this key to the `required` validation keyword array because it is optional.
 
 ```json
@@ -276,7 +276,7 @@ So far our JSON schema has been wholly self contained. It is very common to shar
 
 For this example we introduce a new JSON Schema resource and for both properties therein:
 * We use the `minimum` validation keyword noted earlier.
-* We add the [`maximum`](http://json-schema.org/latest/json-schema-validation.html#rfc.section.6.2.2) validation keyword.
+* We add the [`maximum`](http://json-schema.org/latest/json-schema-validation.html#section-6.2.2) validation keyword.
 * Combined, these give us a range to use in validation.
 
 ```json

--- a/learn/getting-started-step-by-step.md
+++ b/learn/getting-started-step-by-step.md
@@ -57,8 +57,8 @@ We start with four properties called **keywords** which are expressed as [JSON](
 
 ```json
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "http://example.com/product.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.com/product.schema.json",
   "title": "Product",
   "description": "A product in the catalog",
   "type": "object"
@@ -85,8 +85,8 @@ In JSON Schema terms, we update our schema to add:
 
 ```json
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "http://example.com/product.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.com/product.schema.json",
   "title": "Product",
   "description": "A product from Acme's catalog",
   "type": "object",
@@ -106,8 +106,8 @@ In JSON Schema terms, we update our schema to add:
 
 ```json
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "http://example.com/product.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.com/product.schema.json",
   "title": "Product",
   "description": "A product from Acme's catalog",
   "type": "object",
@@ -135,8 +135,8 @@ According to the store owner there are no free products. ;)
 
 ```json
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "http://example.com/product.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.com/product.schema.json",
   "title": "Product",
   "description": "A product from Acme's catalog",
   "type": "object",
@@ -179,8 +179,8 @@ Therefore:
 
 ```json
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "http://example.com/product.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.com/product.schema.json",
   "title": "Product",
   "description": "A product from Acme's catalog",
   "type": "object",
@@ -222,8 +222,8 @@ Up until this point we've been dealing with a very flat schema -- only one level
 
 ```json
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "http://example.com/product.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.com/product.schema.json",
   "title": "Product",
   "description": "A product from Acme's catalog",
   "type": "object",
@@ -282,7 +282,7 @@ For this example we introduce a new JSON Schema resource and for both properties
 ```json
 {
   "$id": "https://example.com/geographical-location.schema.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Longitude and Latitude",
   "description": "A geographical coordinate on a planet (most commonly Earth).",
   "required": [ "latitude", "longitude" ],
@@ -306,8 +306,8 @@ Next we add a reference to this new schema so it can be incorporated.
 
 ```json
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "http://example.com/product.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.com/product.schema.json",
   "title": "Product",
   "description": "A product from Acme's catalog",
   "type": "object",

--- a/learn/miscellaneous-examples.md
+++ b/learn/miscellaneous-examples.md
@@ -20,7 +20,7 @@ This example provides a typical minimum you are likely to see in JSON Schema. It
 ```json
 {
   "$id": "https://example.com/person.schema.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Person",
   "type": "object",
   "properties": {
@@ -62,7 +62,7 @@ This example introduces:
 ```json
 {
   "$id": "https://example.com/geographical-location.schema.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Longitude and Latitude Values",
   "description": "A geographical coordinate.",
   "required": [ "latitude", "longitude" ],
@@ -100,13 +100,13 @@ Arrays are fundamental structures in JSON -- here we demonstrate a couple of way
 
 We also introduce the following with this example:
 
-* [`definitions`](http://json-schema.org/latest/json-schema-validation.html#rfc.section.9) keyword
+* [`$defs`](http://json-schema.org/latest/json-schema-validation.html#rfc.section.9) keyword
 * [`$ref`](http://json-schema.org/latest/json-schema-core.html#rfc.section.8.3) keyword
 
 ```json
 {
   "$id": "https://example.com/arrays.schema.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "description": "A representation of a person, company, organization, or place",
   "type": "object",
   "properties": {
@@ -118,10 +118,10 @@ We also introduce the following with this example:
     },
     "vegetables": {
       "type": "array",
-      "items": { "$ref": "#/definitions/veggie" }
+      "items": { "$ref": "#/$defs/veggie" }
     }
   },
-  "definitions": {
+  "$defs": {
     "veggie": {
       "type": "object",
       "required": [ "veggieName", "veggieLike" ],

--- a/learn/miscellaneous-examples.md
+++ b/learn/miscellaneous-examples.md
@@ -7,15 +7,15 @@ title: Miscellaneous Examples
 
 This example provides a typical minimum you are likely to see in JSON Schema. It contains:
 
-* [`$id`](http://json-schema.org/latest/json-schema-core.html#rfc.section.8.2) keyword
-* [`$schema`](http://json-schema.org/latest/json-schema-core.html#rfc.section.7) keyword
-* [`title`](http://json-schema.org/latest/json-schema-hypermedia.html#rfc.section.6.5.1) annotation keyword
-* [`type`](http://json-schema.org/latest/json-schema-core.html#rfc.section.4.2.1) instance data model
-* [`properties`](http://json-schema.org/latest/json-schema-validation.html#rfc.section.6.5.4) validation keyword
+* [`$id`](http://json-schema.org/latest/json-schema-core.html#section-8.2.1) keyword
+* [`$schema`](http://json-schema.org/latest/json-schema-core.html#section-8.1.1) keyword
+* [`title`](http://json-schema.org/latest/json-schema-validation.html#section-9.1) annotation keyword
+* [`type`](http://json-schema.org/latest/json-schema-validation.html#section-6.1.1) instance data model
+* [`properties`](http://json-schema.org/latest/json-schema-core.html#section-10.3.2.1) validation keyword
 * Three keys: `firstName`, `lastName` and `age` each with their own:
-  * [`description`](http://json-schema.org/latest/json-schema-validation.html#rfc.section.10.1) annotation keyword.
+  * [`description`](http://json-schema.org/latest/json-schema-validation.html#section-9.1) annotation keyword.
   * `type` instance data model (see above).
-* [`minimum`](http://json-schema.org/latest/json-schema-validation.html#rfc.section.6.2.4) validation keyword on the `age` key.
+* [`minimum`](http://json-schema.org/latest/json-schema-validation.html#section-6.2.4) validation keyword on the `age` key.
 
 ```json
 {
@@ -55,9 +55,9 @@ This example provides a typical minimum you are likely to see in JSON Schema. It
 
 This example introduces:
 
-* [`required`](http://json-schema.org/latest/json-schema-validation.html#rfc.section.6.5.3) validation keyword
-* [`minimum`](http://json-schema.org/latest/json-schema-validation.html#rfc.section.6.2.4) validation keyword
-* [`maximum`](http://json-schema.org/latest/json-schema-validation.html#rfc.section.6.2.2) validation keyword
+* [`required`](http://json-schema.org/latest/json-schema-validation.html#section-6.5.3) validation keyword
+* [`minimum`](http://json-schema.org/latest/json-schema-validation.html#section-6.2.4) validation keyword
+* [`maximum`](http://json-schema.org/latest/json-schema-validation.html#section-6.2.2) validation keyword
 
 ```json
 {
@@ -100,8 +100,8 @@ Arrays are fundamental structures in JSON -- here we demonstrate a couple of way
 
 We also introduce the following with this example:
 
-* [`$defs`](http://json-schema.org/latest/json-schema-validation.html#rfc.section.9) keyword
-* [`$ref`](http://json-schema.org/latest/json-schema-core.html#rfc.section.8.3) keyword
+* [`$defs`](http://json-schema.org/latest/json-schema-core.html#section-8.2.4) keyword
+* [`$ref`](http://json-schema.org/latest/json-schema-core.html#section-8.2.3.1) keyword
 
 ```json
 {


### PR DESCRIPTION
This updates all the pages in `/learn` for 2020-12. It updates the `$schema` values, keywords changes (such as `$defs`), and specification links.